### PR TITLE
chore: replace label-syncer action with gh CLI

### DIFF
--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -9,23 +9,51 @@ on:
     paths:
       - label_syncer.yml
 
+env:
+  REPOS: |
+    TomerFi/.github
+    TomerFi/aioswitcher
+    TomerFi/switcher_webapi
+    TomerFi/version-bumper
+    TomerFi/version-bumper-action
+    TomerFi/auto-me-bot
+    TomerFi/github-viewer-stats
+    TomerFi/my-little-helper
+
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
     name: Sync labels
     steps:
       - name: Source checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Label syncer
-        uses: micnncim/action-label-syncer@v1.3.0
-        with:
-          manifest: label_syncer.yml
-          repository: |
-              tomerfi/.github
-              tomerfi/aioswitcher
-              tomerfi/switcher_webapi
-              tomerfi/version-bumper
-              tomerfi/version-bumper-action
-              tomerfi/auto-me-bot
-          token: ${{ secrets.LABEL_SYNCER_PAT }}
+      - name: Sync labels to all repos
+        env:
+          GH_TOKEN: ${{ secrets.LABEL_SYNCER_PAT }}
+        run: |
+          # Install yq
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+          # Loop through each repo
+          echo "$REPOS" | while read -r repo; do
+            [ -z "$repo" ] && continue
+            echo "::group::Syncing labels to $repo"
+
+            # Loop through each label in the manifest
+            yq -o=json '.' label_syncer.yml | jq -c '.[]' | while read -r label; do
+              name=$(echo "$label" | jq -r '.name')
+              color=$(echo "$label" | jq -r '.color')
+              description=$(echo "$label" | jq -r '.description // ""')
+
+              echo "  Creating/updating label: $name"
+              gh label create "$name" \
+                --repo "$repo" \
+                --color "$color" \
+                --description "$description" \
+                --force 2>/dev/null || echo "    Failed to sync label: $name"
+            done
+
+            echo "::endgroup::"
+          done

--- a/label_syncer.yml
+++ b/label_syncer.yml
@@ -1,4 +1,3 @@
-# https://github.com/marketplace/actions/label-syncer
 ---
 # Type labels
 - name: "type: bug"
@@ -25,13 +24,13 @@
 
 # Status labels
 - name: "status: on-hold"
-  color": "fef2c0"
+  color: "fef2c0"
   description: "This issue or pull request is on hold"
 - name: "status: wontfix"
   color: "ffffff"
   description: "This will not be worked on"
 - name: "status: needs information"
-  color": "fef2c0"
+  color: "fef2c0"
   description: "Further information is required"
 - name: "status: duplicate"
   color: "cfd8d7"
@@ -94,7 +93,8 @@
 - name: "good first issue"
   color: "7057ff"
   description: "Good for newcomers"
-# hacktoberfest labels
+
+# Hacktoberfest labels
 - name: "hacktoberfest"
   color: "cfd1d9"
   description: "hacktoberfest"


### PR DESCRIPTION
## Summary
- Replace `micnncim/action-label-syncer` with native `gh label` CLI commands
- Fix YAML syntax errors in `label_syncer.yml` (`color":` → `color:`)
- Add missing repos: `github-viewer-stats`, `my-little-helper`
- Update `actions/checkout` to v4

## Changes
- Workflow now uses `yq` + `jq` to parse the label manifest
- Uses `gh label create --force` to create/update labels
- No external action dependency

## Repos synced
- TomerFi/.github
- TomerFi/aioswitcher
- TomerFi/switcher_webapi
- TomerFi/version-bumper
- TomerFi/version-bumper-action
- TomerFi/auto-me-bot
- TomerFi/github-viewer-stats
- TomerFi/my-little-helper