### PR TITLE
docs: standardize code of conduct enforcement section

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at tomer@tomfi.info. All complaints will
+reported by messaging the project maintainers directly via their GitHub profiles. All complaints will
 be reviewed and investigated and will result in a response that is deemed
 necessary and appropriate to the circumstances. The project team is obligated
 to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
## Summary
- Remove email address from CODE_OF_CONDUCT.md
- Change enforcement contact from "tomer@tomfi.info" to "messaging the project maintainers directly via their GitHub profiles"

## Purpose
Align with standardization across projects to avoid exposing email addresses and use GitHub's communication channels.